### PR TITLE
Set correct install path for Debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(SERVICES_INSTALL_DIR /usr/share/kde4/services)
+set(DATA_INSTALL_DIR /usr/share/kde4/apps)
+set(PLUGIN_INSTALL_DIR /usr/lib/kde4)
+
 project(kdevkernel)
 
 find_package(KDE4 4.7.0 REQUIRED)


### PR DESCRIPTION
Of course this breaks the setup for fedora or other distros.

Therefore this commit is more a quick and dirty solution for debian users 
or somehow issue report. 

For a robust solution detection of the right install path would be necesarry.
